### PR TITLE
Using kraken and kaiju datatypes in Galaxy [WIP]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,9 @@ install:
 script:
  - cd ${TRAVIS_BUILD_DIR}
  - planemo --version
- - planemo test --conda_dependency_resolution --conda_auto_install --conda_channels iuc,bioconda,conda-forge,defaults --galaxy_branch ${GALAXY_BRANCH} .
+ - export GALAXY_REPO=https://github.com/peterjc/galaxy
+ - if [ "${GALAXY_BRANCH}" == "dev" ] then export GALAXY_BRANCH=kk_db; fi
+ - planemo test --conda_dependency_resolution --conda_auto_install --conda_channels iuc,bioconda,conda-forge,defaults --galaxy_branch "${GALAXY_BRANCH}" --galaxy_source "$GALAXY_REPO" .
 
 notifications:
   email: false


### PR DESCRIPTION
This is a work in progress (WIP), testing on TravisCI against my ``kk_bb`` branch of Galaxy which defines compound datatypes for the Kaiju and Kraken databases, see:

https://github.com/galaxyproject/galaxy/pull/5704

The goal is to wrap ``kodoja_build.py`` to create databases as history entries, and then expand ``kodoja_search.xml`` to allow running ``kodoja_search.py`` against databases from the user's history.